### PR TITLE
Share updated timestamp ♻️

### DIFF
--- a/fennec-cli/src/energy/profile.rs
+++ b/fennec-cli/src/energy/profile.rs
@@ -13,7 +13,7 @@ use crate::{
     db::power,
     math::{
         fourier::Harmonic,
-        smoothing::{Clocked, HalfLife},
+        smoothing::{Exponential, HalfLife},
     },
     ops::{BucketIntegrator, BucketMean, Integrator, Interval},
     prelude::*,
@@ -151,27 +151,31 @@ impl Profile {
 #[must_use]
 #[derive(Clone, Encode, Decode)]
 pub struct New {
-    /// Global average energy balance (constant term of the Fourier decomposition).
-    #[musli(Binary, name = 1)]
-    mean_balance: Clocked<Balance<Watts>>,
+    #[musli(Binary, name = 6)]
+    #[musli(with = crate::ops::musli::chrono)]
+    last_updated_at: DateTime<Local>,
 
     /// Average EPS active power.
-    #[musli(Binary, name = 3)]
-    eps_active_power: Clocked<Watts>,
+    #[musli(Binary, name = 7)]
+    eps_active_power: Exponential<Watts>,
 
-    #[musli(Binary, name = 4, default = Self::default_harmonics)]
-    balance_harmonics: Vec<Clocked<Harmonic<Balance<Watts>>>>,
+    /// Global average energy balance (constant term of the Fourier decomposition).
+    #[musli(Binary, name = 8)]
+    mean_balance: Exponential<Balance<Watts>>,
+
+    #[musli(Binary, name = 9)]
+    balance_harmonics: Vec<Exponential<Harmonic<Balance<Watts>>>>,
 }
 
 impl Default for New {
     fn default() -> Self {
-        let now = Local::now();
         Self {
-            mean_balance: Clocked::new(Balance::ZERO, now),
-            eps_active_power: Clocked::new(Watts::ZERO, now),
+            last_updated_at: Local::now(),
+            mean_balance: Exponential::new(Balance::ZERO),
+            eps_active_power: Exponential::new(Watts::ZERO),
 
             // TODO: make number of harmonics configurable?
-            balance_harmonics: vec![Clocked::new(Harmonic::ZERO, now); 8],
+            balance_harmonics: vec![Exponential::new(Harmonic::ZERO); 8],
         }
     }
 }
@@ -213,10 +217,6 @@ impl New {
         *self.mean_balance.value()
     }
 
-    pub const fn balance_harmonics(&self) -> &[Clocked<Harmonic<Balance<Watts>>>] {
-        self.balance_harmonics.as_slice()
-    }
-
     pub fn update(
         &mut self,
         balance: Balance<Watts>,
@@ -224,16 +224,21 @@ impl New {
         at: DateTime<Local>,
         half_life: HalfLife,
     ) {
-        self.eps_active_power.update(eps_active_power, at, half_life);
+        let smoothing_factor = {
+            let elapsed = at - std::mem::replace(&mut self.last_updated_at, at);
+            half_life.smoothing_factor(elapsed)
+        };
+
+        self.eps_active_power.update(eps_active_power, smoothing_factor);
 
         // Deviation is calculated before the mean update eats the signal:
         let deviation = balance - *self.mean_balance.value();
-        self.mean_balance.update(balance, at, half_life);
+        self.mean_balance.update(balance, smoothing_factor);
 
         // Capture daily periodicity, hence one full day is τ radians:
         let base_phase = f64::from(at.time().num_seconds_from_midnight()) / 86400.0 * TAU;
         for (k, harmonic) in (1..).zip(self.balance_harmonics.iter_mut()) {
-            harmonic.update(Harmonic::project(deviation, base_phase, k), at, half_life);
+            harmonic.update(Harmonic::project(deviation, base_phase, k), smoothing_factor);
         }
     }
 
@@ -272,9 +277,5 @@ impl New {
                 harmonic.cosine * cosine_mean + harmonic.sine * sine_mean
             })
             .fold(Balance::ZERO, |sum, item| sum + item)
-    }
-
-    fn default_harmonics() -> Vec<Clocked<Harmonic<Balance<Watts>>>> {
-        vec![Clocked::new(Harmonic::ZERO, Local::now()); 8]
     }
 }

--- a/fennec-cli/src/math/fourier.rs
+++ b/fennec-cli/src/math/fourier.rs
@@ -1,73 +1,9 @@
-use std::{
-    f64::consts::TAU,
-    ops::{Add, Mul, Range},
-};
+use std::ops::Mul;
 
 use derive_more::{AddAssign, Sub};
 use musli::{Decode, Encode};
 
 use crate::quantity::Zero;
-
-#[derive(Encode, Decode)]
-pub struct Decomposition<T> {
-    /// Zero-frequency component.
-    #[musli(Binary, name = 1)]
-    pub mean: T,
-
-    #[musli(Binary, name = 2)]
-    harmonics: Vec<Harmonic<T>>,
-}
-
-impl<T> Decomposition<T> {
-    /// Fourier decomposition with zeroed mean and harmonics.
-    pub fn zero(n_harmonics: usize) -> Self
-    where
-        T: Copy + Zero,
-    {
-        Self { mean: T::ZERO, harmonics: vec![Harmonic::ZERO; n_harmonics] }
-    }
-
-    /// Calculate deviation from the mean at the given base phase.
-    pub fn deviation_at(&self, base_phase: f64) -> T
-    where
-        T: Copy + Add<Output = T> + Mul<f64, Output = T> + Zero,
-    {
-        (1..)
-            .zip(self.harmonics.iter())
-            .map(|(k, harmonic)| {
-                let phase = base_phase * f64::from(k);
-                harmonic.cosine * phase.cos() + harmonic.sine * phase.sin()
-            })
-            .fold(T::ZERO, |sum, item| sum + item)
-    }
-
-    /// Calculate the mean deviation of the balance over the given interval,
-    /// assuming the function is periodic over the unit interval.
-    #[expect(clippy::float_cmp)]
-    pub fn mean_deviation_over(&self, interval: Range<f64>) -> T
-    where
-        T: Copy + Zero + Add<Output = T> + Mul<f64, Output = T>,
-    {
-        assert_ne!(interval.start, interval.end);
-
-        let length = interval.end - interval.start;
-        (1..)
-            .zip(self.harmonics.iter())
-            .map(|(k, harmonic)| {
-                let angular_frequency = TAU * f64::from(k);
-                let cosine_mean = ((angular_frequency * interval.end).sin()
-                    - (angular_frequency * interval.start).sin())
-                    / angular_frequency
-                    / length;
-                let sine_mean = ((angular_frequency * interval.start).cos()
-                    - (angular_frequency * interval.end).cos())
-                    / angular_frequency
-                    / length;
-                harmonic.cosine * cosine_mean + harmonic.sine * sine_mean
-            })
-            .fold(T::ZERO, |sum, item| sum + item)
-    }
-}
 
 /// As single [harmonic][1] from a [harmonic spectrum][2].
 ///

--- a/fennec-cli/src/math/smoothing.rs
+++ b/fennec-cli/src/math/smoothing.rs
@@ -1,11 +1,10 @@
 use std::{
     f64::consts::LN_2,
-    mem::replace,
     ops::{AddAssign, Mul, Sub},
     time::Duration,
 };
 
-use chrono::{DateTime, Local, TimeDelta};
+use chrono::TimeDelta;
 use musli::{Decode, Encode};
 
 /// Raw [exponential moving average][1] with explicit smoothing factor per update.
@@ -75,37 +74,5 @@ impl HalfLife {
     fn decay(self, elapsed: TimeDelta) -> f64 {
         assert!(elapsed >= TimeDelta::zero(), "elapsed time must be non-negative");
         elapsed.as_seconds_f64() * self.0
-    }
-}
-
-/// Exponential moving average with automatic temporal smoothing.
-#[must_use]
-#[derive(Clone, Encode, Decode)]
-pub struct Clocked<V> {
-    #[musli(Binary, name = 1)]
-    smoother: Exponential<V>,
-
-    #[musli(Binary, name = 2)]
-    #[musli(with = crate::ops::musli::chrono)]
-    last_updated_at: DateTime<Local>,
-}
-
-impl<V> Clocked<V> {
-    pub const fn new(initial_value: V, initialized_at: DateTime<Local>) -> Self {
-        Self { smoother: Exponential::new(initial_value), last_updated_at: initialized_at }
-    }
-
-    /// Get the current smoothed value.
-    pub const fn value(&self) -> &V {
-        self.smoother.value()
-    }
-
-    /// Update the moving average according to the elapsed time and decay parameter.
-    pub fn update(&mut self, value: V, at: DateTime<Local>, half_life: HalfLife)
-    where
-        V: Clone + AddAssign + Sub<Output = V> + Mul<f64, Output = V>,
-    {
-        let elapsed = at - replace(&mut self.last_updated_at, at);
-        self.smoother.update(value, half_life.smoothing_factor(elapsed));
     }
 }


### PR DESCRIPTION
`Clocked` was a useful concept but the profile turned to get updated all at the same time, so it makes sense to extract `last_updated_at` nevertheless.