### PR TITLE
Prepping to derive `AsRef` and `AsMut` on `Space` 🚧

### DIFF
--- a/fennec-cli/src/schedule.rs
+++ b/fennec-cli/src/schedule.rs
@@ -51,6 +51,8 @@ impl<V> Schedule<V> {
     }
 
     /// Construct new schedule by mapping the schedule values.
+    ///
+    /// TODO: consume `self`.
     pub fn map<T>(&self, mapper: impl Fn(&V) -> T) -> Schedule<T> {
         Schedule(self.0.iter().map(|slot| slot.map(&mapper)).collect())
     }
@@ -105,6 +107,7 @@ pub struct Slot<V> {
 }
 
 impl<V> Slot<V> {
+    /// TODO: consume `self`.
     pub fn map<T>(&self, mapper: impl FnOnce(&V) -> T) -> Slot<T> {
         Slot { interval: self.interval, value: mapper(&self.value) }
     }

--- a/fennec-cli/src/solution.rs
+++ b/fennec-cli/src/solution.rs
@@ -7,7 +7,6 @@ mod step;
 use std::cmp::Ordering;
 
 pub use self::{losses::Losses, metrics::Metrics, solver::Solver, space::Space, step::Step};
-use crate::quantity::Zero;
 
 #[must_use]
 #[derive(Copy, Clone)]
@@ -18,11 +17,6 @@ pub struct Solution {
     ///
     /// Boundary solutions have [`None`] here.
     pub step: Option<Step>,
-}
-
-impl Solution {
-    /// Empty solution that is returned for the time interval beyond the forecast horizon.
-    pub const BOUNDARY: Self = Self { metrics: Metrics::ZERO, step: None };
 }
 
 impl Eq for Solution {}

--- a/fennec-cli/src/solution/losses.rs
+++ b/fennec-cli/src/solution/losses.rs
@@ -1,9 +1,9 @@
-use derive_more::Add;
+use derive_more::{Add, AddAssign};
 
 use crate::quantity::{Zero, currency::Mills};
 
 #[must_use]
-#[derive(Copy, Clone, Add)]
+#[derive(Copy, Clone, Add, AddAssign)]
 pub struct Losses {
     /// Cumulative loss to the grid till the end of the forecast period.
     pub grid: Mills,

--- a/fennec-cli/src/solution/metrics.rs
+++ b/fennec-cli/src/solution/metrics.rs
@@ -1,4 +1,4 @@
-use derive_more::Add;
+use derive_more::{Add, AddAssign};
 
 use crate::{
     energy::Flow,
@@ -7,7 +7,7 @@ use crate::{
 };
 
 #[must_use]
-#[derive(Copy, Clone, Add)]
+#[derive(Copy, Clone, Add, AddAssign)]
 pub struct Metrics {
     pub internal_battery_flow: Flow<WattHours>,
     pub losses: Losses,

--- a/fennec-cli/src/solution/solver.rs
+++ b/fennec-cli/src/solution/solver.rs
@@ -118,9 +118,16 @@ impl Solver<'_> {
                     // At or above the maximum allowed energy level, forbid going higher:
                     return None;
                 }
-                // Note that the next solution may not exist, hence the question mark:
-                let next_solution = solutions.get(interval_index + 1, step.energy_level_after)?;
-                Some(Solution { metrics: step.metrics + next_solution.metrics, step: Some(step) })
+
+                let mut metrics = step.metrics;
+                let next_interval_index = interval_index + 1;
+
+                if next_interval_index < self.energy_prices.len() {
+                    // For non-boundary solutions, accumulate the target optimization metrics:
+                    metrics += solutions.get(next_interval_index, step.energy_level_after)?.metrics;
+                }
+
+                Some(Solution { metrics, step: Some(step) })
             })
             .min()
     }

--- a/fennec-cli/src/solution/space.rs
+++ b/fennec-cli/src/solution/space.rs
@@ -1,4 +1,4 @@
-use std::{cmp::Ordering, iter::from_fn};
+use std::iter::from_fn;
 
 use crate::{
     Schedule,
@@ -24,11 +24,7 @@ impl Space {
     /// Get the solution at the given time slot index and energy.
     #[must_use]
     pub fn get(&self, interval_index: usize, energy_level: EnergyLevel) -> Option<&Solution> {
-        match interval_index.cmp(&self.0.len()) {
-            Ordering::Less => self.0.get(interval_index).value[energy_level.0].as_ref(),
-            Ordering::Equal => Some(&Solution::BOUNDARY),
-            Ordering::Greater => panic!("interval index is out of bounds ({interval_index})"),
-        }
+        self.0.get(interval_index).value[energy_level.0].as_ref()
     }
 
     /// Get the mutable solution at the given time slot index and energy.


### PR DESCRIPTION
The goal is to lay the groundwork to remove `get` and `get_mut` on `Space` in favour of direct access from `Solver`.