### PR TITLE
Consolidate metrics ♻️

### DIFF
--- a/fennec-cli/src/api/mini_qube.rs
+++ b/fennec-cli/src/api/mini_qube.rs
@@ -7,7 +7,6 @@ pub mod schedule;
 
 use std::array::from_fn;
 
-use chrono::Local;
 use fennec_modbus::{
     contrib::{
         mini_qube,
@@ -17,7 +16,7 @@ use fennec_modbus::{
     tcp::UnitId,
 };
 
-pub use self::metrics::{Metrics, Tracked as TrackedMetrics, Untracked as UntrackedMetrics};
+pub use self::metrics::Metrics;
 use crate::{energy::Flow, prelude::*};
 
 /// FoxESS MQ2200 Modbus client.
@@ -31,28 +30,21 @@ impl Client {
         Self(fennec_modbus::tcp::tokio::Client::new(address))
     }
 
-    pub async fn read_metrics(&self) -> Result<Metrics> {
-        Ok(Metrics {
-            tracked: self.read_tracked_metrics().await?,
-            untracked: self.read_untracked_metrics().await?,
-        })
-    }
-
     #[instrument(skip_all)]
-    async fn read_tracked_metrics(&self) -> Result<TrackedMetrics> {
+    pub async fn read_metrics(&self) -> Result<Metrics> {
         let design_capacity = self
             .0
             .call::<mini_qube::ReadDesignCapacity>(Self::UNIT_ID, address::Const)
             .await
             .context("failed to read the design capacity")?
             .into();
-        let health = self
+        let state_of_health = self
             .0
             .call::<mini_qube::ReadStateOfHealth>(Self::UNIT_ID, address::Const)
             .await
             .context("failed to read the SoH")?
             .try_into()?;
-        let charge = self
+        let state_of_charge = self
             .0
             .call::<mini_qube::ReadStateOfCharge>(Self::UNIT_ID, address::Const)
             .await
@@ -70,21 +62,19 @@ impl Client {
             .await
             .context("failed to read the total exported energy")?
             .into();
+        let active_power = self
+            .0
+            .call::<mini_qube::ReadTotalActivePower>(Self::UNIT_ID, address::Const)
+            .await
+            .context("failed to read the active power")?
+            .into();
+        let eps_active_power = self
+            .0
+            .call::<mini_qube::ReadEpsActivePower>(Self::UNIT_ID, address::Const)
+            .await
+            .context("failed to read the EPS active power")?
+            .into();
 
-        Ok(TrackedMetrics {
-            timestamp: Local::now(),
-            charge,
-            health,
-            design_capacity,
-            total_grid_flow: Flow {
-                import: total_grid_import_energy,
-                export: total_grid_export_energy,
-            },
-        })
-    }
-
-    #[instrument(skip_all)]
-    async fn read_untracked_metrics(&self) -> Result<UntrackedMetrics> {
         // TODO: these two are only needed when optimizing:
         let min_soc = self
             .0
@@ -99,20 +89,14 @@ impl Client {
             .context("failed to read the max SoC")?
             .try_into()?;
 
-        let active_power = self
-            .0
-            .call::<mini_qube::ReadTotalActivePower>(Self::UNIT_ID, address::Const)
-            .await
-            .context("failed to read the active power")?
-            .into();
-        let eps_active_power = self
-            .0
-            .call::<mini_qube::ReadEpsActivePower>(Self::UNIT_ID, address::Const)
-            .await
-            .context("failed to read the EPS active power")?
-            .into();
-
-        Ok(UntrackedMetrics {
+        Ok(Metrics {
+            state_of_charge,
+            state_of_health,
+            design_capacity,
+            total_grid_flow: Flow {
+                import: total_grid_import_energy,
+                export: total_grid_export_energy,
+            },
             allowed_soc: (min_soc..=max_soc).into(),
             active_power,
             eps_active_power,

--- a/fennec-cli/src/api/mini_qube/metrics.rs
+++ b/fennec-cli/src/api/mini_qube/metrics.rs
@@ -1,8 +1,5 @@
 use std::range::RangeInclusive;
 
-use chrono::{DateTime, Local};
-use musli::{Decode, Encode};
-
 use crate::{
     energy::Flow,
     quantity::{
@@ -14,25 +11,16 @@ use crate::{
 
 #[must_use]
 pub struct Metrics {
-    pub tracked: Tracked,
-    pub untracked: Untracked,
-}
+    /// State-of-charge (SoC) percentage.
+    pub state_of_charge: Percentage,
 
-impl Metrics {
-    /// Minimum allowed residual charge.
-    pub fn min_residual_charge(&self) -> WattHours {
-        self.tracked.actual_capacity() * self.untracked.allowed_soc.start
-    }
+    /// State-of-health (SoH) percentage.
+    pub state_of_health: Percentage,
 
-    /// Maximum allowed residual charge.
-    pub fn max_residual_charge(&self) -> WattHours {
-        self.tracked.actual_capacity() * self.untracked.allowed_soc.last
-    }
-}
+    pub design_capacity: DecawattHours,
 
-/// Untracked metrics are throw away directly after processing.
-#[must_use]
-pub struct Untracked {
+    pub total_grid_flow: Flow<DecawattHours>,
+
     /// Allowed state-of-charge range.
     pub allowed_soc: RangeInclusive<Percentage>,
 
@@ -45,38 +33,24 @@ pub struct Untracked {
     pub eps_active_power: Watts,
 }
 
-/// Tracked metrics are persisted in order to estimate the battery parameters.
-#[must_use]
-#[derive(Copy, Clone, Encode, Decode)]
-pub struct Tracked {
-    /// Timestamp of the readings.
-    #[musli(Binary, name = 1)]
-    #[musli(with = crate::ops::musli::chrono)]
-    pub timestamp: DateTime<Local>,
+impl Metrics {
+    /// Minimum allowed residual charge.
+    pub fn min_residual_charge(&self) -> WattHours {
+        self.actual_capacity() * self.allowed_soc.start
+    }
 
-    /// State-of-charge (SoC) percentage.
-    #[musli(Binary, name = 2)]
-    pub charge: Percentage,
+    /// Maximum allowed residual charge.
+    pub fn max_residual_charge(&self) -> WattHours {
+        self.actual_capacity() * self.allowed_soc.last
+    }
 
-    /// State-of-health (SoH) percentage.
-    #[musli(Binary, name = 3)]
-    pub health: Percentage,
-
-    #[musli(Binary, name = 4)]
-    pub design_capacity: DecawattHours,
-
-    #[musli(Binary, name = 7)]
-    pub total_grid_flow: Flow<DecawattHours>,
-}
-
-impl Tracked {
     /// Battery capacity corrected on the state of health.
     pub fn actual_capacity(&self) -> WattHours {
-        self.design_capacity.rescale() * self.health
+        self.design_capacity.rescale() * self.state_of_health
     }
 
     /// Residual energy corrected on the state of health.
     pub fn residual_energy(&self) -> MilliwattHours {
-        self.design_capacity * (self.health * self.charge)
+        self.design_capacity * (self.state_of_health * self.state_of_charge)
     }
 }

--- a/fennec-cli/src/energy/profile.rs
+++ b/fennec-cli/src/energy/profile.rs
@@ -79,7 +79,7 @@ impl Profile {
     #[must_use]
     pub fn track_battery_metrics(
         &mut self,
-        current_metrics: mini_qube::TrackedMetrics,
+        current_metrics: &mini_qube::Metrics,
         half_life_factor: f64,
     ) -> bool {
         let battery_tracker = BatteryTracker {

--- a/fennec-cli/src/main.rs
+++ b/fennec-cli/src/main.rs
@@ -155,15 +155,15 @@ impl Engine {
             .notify(log_retried_error)
             .await?;
 
-        let net_deficit = grid_metrics.active_power + battery_metrics.untracked.active_power;
+        let net_deficit = grid_metrics.active_power + battery_metrics.active_power;
         let balance = energy::Balance::new(self.args.battery.power_limits, net_deficit);
         debug!(
             ?net_deficit,
-            battery.active_power = ?battery_metrics.untracked.active_power,
-            battery.eps_active_power = ?battery_metrics.untracked.eps_active_power,
-            battery.residual_energy = ?battery_metrics.tracked.residual_energy(),
-            battery.health = ?battery_metrics.tracked.health,
-            battery.actual_capacity = ?battery_metrics.tracked.actual_capacity(),
+            battery.active_power = ?battery_metrics.active_power,
+            battery.eps_active_power = ?battery_metrics.eps_active_power,
+            battery.residual_energy = ?battery_metrics.residual_energy(),
+            battery.state_of_health = ?battery_metrics.state_of_health,
+            battery.actual_capacity = ?battery_metrics.actual_capacity(),
             ?balance.battery.export,
             ?balance.battery.import,
             ?balance.grid.export,
@@ -193,7 +193,7 @@ impl Engine {
             let solutions = optimizer.solve(&self.energy_prices); // TODO: consume energy prices.
             let backtrack = {
                 let initial_energy_level =
-                    WattHours::from(battery_metrics.tracked.residual_energy()).into();
+                    WattHours::from(battery_metrics.residual_energy()).into();
                 solutions.backtrack(initial_energy_level)?
             };
             info!(
@@ -203,7 +203,7 @@ impl Engine {
                 battery.discharge = ?backtrack.metrics.internal_battery_flow.export,
                 "solution summary",
             );
-            self.write_schedule(&backtrack.schedule, battery_metrics.untracked.allowed_soc).await?;
+            self.write_schedule(&backtrack.schedule, battery_metrics.allowed_soc).await?;
             self.state.write().await.backtrack = Some(backtrack);
         }
 
@@ -263,12 +263,12 @@ impl Engine {
         let energy_profile = &mut self.state.write().await.energy_profile;
         energy_profile.update_energy_balance(
             balance,
-            battery_metrics.untracked.eps_active_power,
+            battery_metrics.eps_active_power,
             now,
             self.args.energy_profile.balance_half_life,
         );
         let is_residual_energy_changed = energy_profile.track_battery_metrics(
-            battery_metrics.tracked,
+            battery_metrics,
             self.args.energy_profile.battery_efficiency_half_life_factor,
         );
         energy_profile.write_to_file().await.context("failed to write the energy profile")?;

--- a/fennec-cli/src/solution/optimizer.rs
+++ b/fennec-cli/src/solution/optimizer.rs
@@ -44,7 +44,7 @@ impl Optimizer {
         let min_energy_level = EnergyLevel::from(battery_metrics.min_residual_charge());
         let max_energy_level = EnergyLevel::from(battery_metrics.max_residual_charge());
         Self {
-            battery_capacity: battery_metrics.tracked.actual_capacity(),
+            battery_capacity: battery_metrics.actual_capacity(),
             max_battery_flow: battery_args
                 .power_limits
                 .max_effective_flow(energy_profile.balance.eps_active_power.0),


### PR DESCRIPTION
Now that the `Profile` uses explicit `BatteryTracker`, there is no reason to separate the battery metrics. We can unite them back.