### PR TITLE
Optimizer to own solution space 🚧

### DIFF
--- a/fennec-cli/src/engine.rs
+++ b/fennec-cli/src/engine.rs
@@ -1,7 +1,7 @@
 use std::{range::RangeInclusive, sync::Arc, time::Duration};
 
 use backon::{ConstantBuilder, Retryable};
-use chrono::{DateTime, Local, TimeDelta};
+use chrono::{DateTime, Local};
 use tokio::{sync::RwLock, time::MissedTickBehavior, try_join};
 
 use crate::{
@@ -25,16 +25,8 @@ pub struct State {
 
 #[must_use]
 pub struct Engine {
-    /// API connections.
     connections: Connections,
-
     args: EngineArgs,
-
-    /// Current energy prices.
-    ///
-    /// TODO: we'll have that in `steps`.
-    energy_prices: Schedule<energy::Flow<KilowattHourPrice>>,
-
     state: Arc<RwLock<State>>,
 }
 
@@ -45,11 +37,9 @@ impl Engine {
     pub async fn start(connections: Connections, args: EngineArgs) -> Result<Self> {
         let energy_profile =
             energy::Profile::read_from_file(args.energy_profile.n_balance_harmonics).await?;
-        let energy_provider = args.energy_provider;
         let this = Self {
             connections,
             args,
-            energy_prices: energy_provider.get_future_prices(Local::now()).await?,
             state: Arc::new(RwLock::new(State { energy_profile, plan: None })),
         };
         Ok(this)
@@ -59,7 +49,7 @@ impl Engine {
         self.state.clone()
     }
 
-    pub async fn run_forever(mut self) -> Result {
+    pub async fn run_forever(self) -> Result {
         let mut interval = tokio::time::interval(self.args.interval);
         interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
         loop {
@@ -68,7 +58,7 @@ impl Engine {
         }
     }
 
-    pub async fn run_once(&mut self) -> Result {
+    pub async fn run_once(&self) -> Result {
         let now = Local::now();
         let (battery_metrics, grid_metrics) = (async || self.read_metrics().await)
             .retry(Self::BACKOFF)
@@ -91,31 +81,26 @@ impl Engine {
             "measurements",
         );
 
+        // TODO: advance the solution space.
         let has_residual_charge_changed =
             // TODO: must also react on min-max SoC settings.
+            // TODO: `Engine` or owned struct should own last know last residual charge and SoC settings.
             self.update_energy_profile(now, balance, &battery_metrics).await?;
-        let has_schedule_advanced = {
-            let previous_len = self.energy_prices.len();
-            self.energy_prices.advance_to(now);
-            self.energy_prices.len() != previous_len
-        };
-        if has_residual_charge_changed || has_schedule_advanced {
-            if self.energy_prices.duration() <= TimeDelta::hours(12) {
-                // When the time comes, try to fetch the tomorrow prices:
-                self.energy_prices = self.args.energy_provider.get_future_prices(now).await?;
-                // TODO: figure out whether the new prices came in.
-            }
+        if has_residual_charge_changed {
+            // TODO: should only update when `solution_space.duration() <= TimeDelta::hours(12)`.
+            let energy_prices = self.args.energy_provider.get_future_prices(now).await?;
             let plan = {
-                let optimizer = Optimizer::new(
+                // TODO: own the optimizer.
+                let mut optimizer = Optimizer::new(
                     self.state.read().await.energy_profile.clone(),
                     &self.args.battery,
                     battery_metrics.actual_capacity(),
                     battery_metrics.allowed_energy_levels(),
                 );
-                let solution_space = optimizer.solve(&self.energy_prices); // TODO: consume energy prices?
+                optimizer.solve(&energy_prices);
                 let initial_energy_level =
                     WattHours::from(battery_metrics.residual_energy()).into();
-                solution_space.backtrack(initial_energy_level)?
+                optimizer.solution_space().backtrack(initial_energy_level)?
             };
             info!(
                 grid_loss = ?plan.metrics.losses.grid,

--- a/fennec-cli/src/solution/optimizer.rs
+++ b/fennec-cli/src/solution/optimizer.rs
@@ -19,18 +19,12 @@ use crate::{
 
 pub struct Optimizer {
     battery_capacity: WattHours,
-
-    /// Maximum power flow that the battery supports.
     max_battery_flow: energy::Flow<Watts>,
-
-    /// Allowed energy level range.
     allowed_energy_levels: RangeInclusive<WattHours<usize>>,
-
     battery_degradation_cost: KilowattHourPrice,
-
     working_modes: Vec<WorkingMode>,
-
     energy_profile: energy::Profile,
+    solution_space: Space,
 }
 
 impl Optimizer {
@@ -49,7 +43,14 @@ impl Optimizer {
             allowed_energy_levels,
             battery_degradation_cost: battery_args.degradation_cost,
             working_modes: battery_args.working_modes.clone(),
+
+            // TODO: this is better done by type state, but that would require forwarding the above args.
+            solution_space: Schedule::new(),
         }
+    }
+
+    pub const fn solution_space(&self) -> &Space {
+        &self.solution_space
     }
 
     /// Populate the solution space from scratch.
@@ -66,41 +67,35 @@ impl Optimizer {
     ///
     /// [1]: https://en.wikipedia.org/wiki/Dynamic_programming
     #[instrument(skip_all)]
-    pub fn solve(&self, energy_prices: &Schedule<energy::Flow<KilowattHourPrice>>) -> Space {
+    pub fn solve(&mut self, energy_prices: &Schedule<energy::Flow<KilowattHourPrice>>) {
         let start_instant = Instant::now();
 
         info!(?self.allowed_energy_levels, n_intervals = energy_prices.len(), "optimizing…");
 
         let capacity_level = EnergyLevel::from(self.battery_capacity);
-        let mut solution_space = energy_prices.map(|price| Stage::new(*price, capacity_level));
+        self.solution_space = energy_prices.map(|price| Stage::new(*price, capacity_level));
 
         // Going backwards:
-        for interval_index in (0..solution_space.len()).rev() {
+        for interval_index in (0..self.solution_space.len()).rev() {
             // Calculate partial solutions for the current time interval:
             for energy_level in (0..=capacity_level.0).map(Quantity) {
-                self.optimize_state(interval_index, energy_level, &mut solution_space);
+                self.optimize_state(interval_index, energy_level);
             }
         }
 
         info!(elapsed = ?start_instant.elapsed(), "optimized");
-        solution_space
     }
 
     /// Optimize the state and assign the solution.
-    pub fn optimize_state(
-        &self,
-        interval_index: usize,
-        initial_energy_level: EnergyLevel,
-        solution_space: &mut Space, // TODO: this goes to an attribute. But how to ensure it's solved?
-    ) {
-        let Slot { interval, value: stage } = solution_space.get(interval_index);
+    pub fn optimize_state(&mut self, interval_index: usize, initial_energy_level: EnergyLevel) {
+        let Slot { interval, value: stage } = self.solution_space.get(interval_index);
         let average_balance = self.energy_profile.balance.mean_over(interval);
         let battery_simulator = battery::Simulator {
             residual_energy: initial_energy_level.into(),
             capacity: self.battery_capacity,
             efficiency: self.energy_profile.battery.efficiency,
         };
-        solution_space.get_mut(interval_index)[initial_energy_level] = self
+        self.solution_space.get_mut(interval_index)[initial_energy_level] = self
             .working_modes
             .iter()
             .copied()
@@ -128,9 +123,9 @@ impl Optimizer {
                 let mut metrics = step.metrics;
                 let next_interval_index = interval_index + 1;
 
-                if next_interval_index < solution_space.len() {
+                if next_interval_index < self.solution_space.len() {
                     // For non-boundary solutions, accumulate the target optimization metrics:
-                    metrics += solution_space.get(next_interval_index).value
+                    metrics += self.solution_space.get(next_interval_index).value
                         [step.energy_level_after]
                         .as_ref()?
                         .metrics;


### PR DESCRIPTION
Transitional step towards `Engine` owning `Optimizer`. The latter will own the solution space and provide `optimize_state` for online re-optimization.

In the future, `Engine` will own `Option<Optimizer>` and only fully re-optimize when new prices come in.

Open question: `Optimizer` may now exist with empty solution space. Technically, it's solvable with a type-state but it would introduce a lot of boilerplate.