### PR TITLE
Introduce minimum final residual energy ✨

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,7 +787,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fennec-cli"
-version = "0.95.1"
+version = "0.95.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "fennec-modbus"
-version = "0.95.1"
+version = "0.95.2"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["foxess", "frank-energie", "home-battery"]
 license = "MIT"
 repository = "https://github.com/eigenein/fennec"
 rust-version = "1.97"
-version = "0.95.1"
+version = "0.95.2"
 
 [workspace.lints.rustdoc]
 broken_intra_doc_links = "deny"

--- a/fennec-cli/src/cli.rs
+++ b/fennec-cli/src/cli.rs
@@ -6,7 +6,7 @@ use crate::{
     energy,
     math::smoothing::HalfLife,
     prelude::*,
-    quantity::time::Hours,
+    quantity::{energy::WattHours, time::Hours},
 };
 
 /// Root CLI arguments.
@@ -40,6 +40,13 @@ pub struct EngineArgs {
 
     #[clap(flatten)]
     pub energy_profile: EnergyProfileArgs,
+
+    #[clap(
+        long = "min-final-residual-energy-watt-hours",
+        env = "MIN_FINAL_RESIDUAL_ENERGY_WATT_HOURS",
+        default_value = "0"
+    )]
+    pub min_final_residual_energy: WattHours<usize>,
 
     /// Do not push schedule to the device, dry run.
     #[clap(long, alias = "scout", env = "DRY_RUN")]

--- a/fennec-cli/src/engine.rs
+++ b/fennec-cli/src/engine.rs
@@ -212,6 +212,7 @@ impl Engine {
             &self.args.battery,
             battery_capacity,
             allowed_residual_energy,
+            self.args.min_final_residual_energy,
         );
         optimizer.solve(prices);
         optimizer

--- a/fennec-cli/src/solution/optimizer.rs
+++ b/fennec-cli/src/solution/optimizer.rs
@@ -25,6 +25,9 @@ pub struct Optimizer {
     /// Allowed residual energy levels per the battery settings.
     allowed_residual_energy: RangeInclusive<WattHours<usize>>,
 
+    /// Minimal residual energy required by the end of the prices' horizon.
+    min_final_residual_energy: WattHours<usize>,
+
     /// Incurred costs per energy flow to and from the battery.
     battery_degradation_cost: KilowattHourPrice,
 
@@ -44,6 +47,7 @@ impl Optimizer {
         battery_args: &battery::Args,
         battery_capacity: WattHours,
         allowed_residual_energy: RangeInclusive<WattHours<usize>>,
+        min_final_residual_energy: WattHours<usize>,
     ) -> Self {
         Self {
             battery_capacity,
@@ -52,6 +56,7 @@ impl Optimizer {
                 .max_effective_flow(energy_profile.energy.eps_active_power.0),
             energy_profile,
             allowed_residual_energy,
+            min_final_residual_energy,
             battery_degradation_cost: battery_args.degradation_cost,
             working_modes: battery_args.working_modes.clone(),
             solution_space: Series::new(),
@@ -161,6 +166,9 @@ impl Optimizer {
                         [step.residual_energy_after]
                         .as_ref()?
                         .metrics;
+                } else if step.residual_energy_after < self.min_final_residual_energy {
+                    // Enforce the final residual energy:
+                    return None;
                 }
 
                 Some(Solution { metrics, step })


### PR DESCRIPTION
This allows to reserve some predefined residual energy before the next-day EPEX prices would come in.